### PR TITLE
chore: upgrade bazel_dep versions

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,11 +4,11 @@ module(
 )
 
 bazel_dep(name = "aspect_bazel_lib", version = "2.22.5")
-bazel_dep(name = "aspect_rules_js", version = "2.9.2")
+bazel_dep(name = "aspect_rules_js", version = "3.2.2")
 bazel_dep(name = "buildozer", version = "8.5.1")
-bazel_dep(name = "rules_nodejs", version = "6.7.3")
-bazel_dep(name = "rules_python", version = "2.0.0")
-bazel_dep(name = "rules_shell", version = "0.6.1")
+bazel_dep(name = "rules_nodejs", version = "6.7.4")
+bazel_dep(name = "rules_python", version = "2.1.0-rc0")
+bazel_dep(name = "rules_shell", version = "0.8.0")
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(


### PR DESCRIPTION
This PR upgrades bazel_dep versions in MODULE.bazel to the latest available in the BCR.

* aspect_rules_js: 2.9.2 -> 3.2.2
* rules_nodejs: 6.7.3 -> 6.7.4
* rules_python: 2.0.0 -> 2.1.0-rc0
* rules_shell: 0.6.1 -> 0.8.0